### PR TITLE
Support versioned key

### DIFF
--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -20,7 +20,7 @@ class ListCommand(BaijiCommand):
     uri = cli.Flag(["-B", "--uri"], help='This option does nothing. It used to return URIs instead of paths, but this is now the default.')
     detail = cli.Flag(['-l', '--detail'], help='print details, like `ls -l`')
     shallow = cli.Flag("--shallow", help='process key names hierarchically and return only immediate "children" (like ls, instead of like find)')
-    list_versions = cli.Flag(['--list-versions'], help='print details, like `ls -l`')
+    list_versions = cli.Flag(['--list-versions'], help='print all versions')
 
     def main(self, key):
         if self.uri:

--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -92,9 +92,8 @@ class MoveCommand(BaijiCommand):
     progress = cli.Flag(['-P', '--progress'], help='show progress bar')
     gzip = cli.Flag(['-z', '--gzip'], help='Store compressed')
     encrypt = cli.Flag('--no-encrypt', default=True, help='Do not server side encrypt at rest')
-    version_id = cli.SwitchAttr('--version-id', str, default=None, help='s3 object version ID')
     def main(self, src, dst):
-        s3.mv(src, dst, force=self.force, progress=self.progress, encrypt=self.encrypt, gzip=self.gzip, version_id=self.version_id)
+        s3.mv(src, dst, force=self.force, progress=self.progress, encrypt=self.encrypt, gzip=self.gzip)
 
 class TouchCommand(BaijiCommand):
     DESCRIPTION = "touch a file on s3"

--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -65,6 +65,7 @@ class CopyCommand(BaijiCommand):
     gzip = cli.Flag(['-z', '--gzip'], help='Store compressed')
     policy = cli.SwitchAttr('--policy', str, help='override policy when copying to s3 (e.g. private, public-read, bucket-owner-read')
     encoding = cli.SwitchAttr('--encoding', str, help='Content-Encoding: gzip, etc')
+    version_id = cli.SwitchAttr('--version-id', str, default=None, help='s3 object version ID')
     def main(self, src, dst):
         kwargs = {
             'force': self.force,
@@ -75,6 +76,7 @@ class CopyCommand(BaijiCommand):
             'encrypt': self.encrypt,
             'gzip': self.gzip,
             'skip': self.skip,
+            'version_id': self.version_id,
         }
         if self.recursive or self.recursive_parallel:
             s3.cp_r(src, dst, parallel=self.recursive_parallel, **kwargs)
@@ -87,8 +89,9 @@ class MoveCommand(BaijiCommand):
     progress = cli.Flag(['-P', '--progress'], help='show progress bar')
     gzip = cli.Flag(['-z', '--gzip'], help='Store compressed')
     encrypt = cli.Flag('--no-encrypt', default=True, help='Do not server side encrypt at rest')
+    version_id = cli.SwitchAttr('--version-id', str, default=None, help='s3 object version ID')
     def main(self, src, dst):
-        s3.mv(src, dst, force=self.force, progress=self.progress, encrypt=self.encrypt, gzip=self.gzip)
+        s3.mv(src, dst, force=self.force, progress=self.progress, encrypt=self.encrypt, gzip=self.gzip, version_id=version_id)
 
 class TouchCommand(BaijiCommand):
     DESCRIPTION = "touch a file on s3"
@@ -117,6 +120,7 @@ class SyncCommand(BaijiCommand):
 class ExistsCommand(BaijiCommand):
     DESCRIPTION = "check if a file exists on s3"
     retries = cli.SwitchAttr('--retries', int, help='how many times to retry', default=3)
+    version_id = cli.SwitchAttr('--version-id', str, default=None, help='s3 object version ID')
     def main(self, key):
         if not s3.exists(key, retries_allowed=self.retries):
             return -1

--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -94,7 +94,7 @@ class MoveCommand(BaijiCommand):
     encrypt = cli.Flag('--no-encrypt', default=True, help='Do not server side encrypt at rest')
     version_id = cli.SwitchAttr('--version-id', str, default=None, help='s3 object version ID')
     def main(self, src, dst):
-        s3.mv(src, dst, force=self.force, progress=self.progress, encrypt=self.encrypt, gzip=self.gzip, version_id=version_id)
+        s3.mv(src, dst, force=self.force, progress=self.progress, encrypt=self.encrypt, gzip=self.gzip, version_id=self.version_id)
 
 class TouchCommand(BaijiCommand):
     DESCRIPTION = "touch a file on s3"

--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -49,11 +49,12 @@ class RemoveCommand(BaijiCommand):
     DESCRIPTION = "delete files on s3"
     recursive = cli.Flag(['-r', '--recursive'], help='remove everything below key')
     force = cli.Flag(['-f', '--force'], help="don't prompt for confirmation on recursive rm")
+    version_id = cli.SwitchAttr('--version-id', str, default=None, help='s3 object version ID')
     def main(self, key):
         if self.recursive:
             s3.rm_r(key, force=self.force)
         else:
-            s3.rm(key)
+            s3.rm(key, version_id=self.version_id)
 
 class CopyCommand(BaijiCommand):
     DESCRIPTION = "copy files from or to s3"

--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -20,17 +20,19 @@ class ListCommand(BaijiCommand):
     uri = cli.Flag(["-B", "--uri"], help='This option does nothing. It used to return URIs instead of paths, but this is now the default.')
     detail = cli.Flag(['-l', '--detail'], help='print details, like `ls -l`')
     shallow = cli.Flag("--shallow", help='process key names hierarchically and return only immediate "children" (like ls, instead of like find)')
+    list_versions = cli.Flag(['--list-versions'], help='print details, like `ls -l`')
+
     def main(self, key):
         if self.uri:
             print "-B and --uri are deprecated options"
         try:
-            keys = s3.ls(key, return_full_urls=True, require_s3_scheme=True, shallow=self.shallow)
+            keys = s3.ls(key, return_full_urls=True, require_s3_scheme=True, shallow=self.shallow, list_versions=self.list_versions)
             if self.detail:
                 from baiji.util.console import sizeof_format_human_readable
                 for key in keys:
                     info = s3.info(key)
                     enc = " enc" if info['encrypted'] else "    "
-                    print "%s\t%s%s\t%s" % (sizeof_format_human_readable(info['size']), info['last_modified'], enc, key.encode('utf-8'),)
+                    print "%s\t%s%s\t%s\t%s" % (sizeof_format_human_readable(info['size']), info['last_modified'], enc, key.encode('utf-8'), info['version_id'])
             else:
                 print u"\n".join(keys).encode('utf-8')
         except s3.InvalidSchemeException as e:

--- a/baiji/connection.py
+++ b/baiji/connection.py
@@ -66,7 +66,7 @@ class S3Connection(object):
 
         return bucket.lookup(key)
 
-    def cp(self, key_or_file_from, key_or_file_to, force=False, progress=False, policy=None, preserve_acl=False, encoding=None, encrypt=True, gzip=False, content_type=None, guess_content_type=False, metadata=None, skip=False, validate=True, max_size=None):
+    def cp(self, key_or_file_from, key_or_file_to, force=False, progress=False, policy=None, preserve_acl=False, encoding=None, encrypt=True, gzip=False, content_type=None, guess_content_type=False, metadata=None, skip=False, validate=True, max_size=None, version=None):
         """
         Copy file to or from AWS S3
 
@@ -95,6 +95,7 @@ class S3Connection(object):
         op.skip = skip
         op.validate = validate
         op.max_size = max_size
+        op.version = version
 
         if guess_content_type:
             op.guess_content_type()
@@ -292,6 +293,7 @@ class S3Connection(object):
             result['encrypted'] = bool(remote_object.encrypted)
             result['acl'] = remote_object.get_acl()
             result['owner'] = remote_object.owner
+            result['version_id'] = remote_object.version_id
         else:
             raise InvalidSchemeException("URI Scheme %s is not implemented" % k.scheme)
         return result

--- a/baiji/connection.py
+++ b/baiji/connection.py
@@ -202,7 +202,7 @@ class S3Connection(object):
             if not quiet:
                 print "[deleted] %s" % url
 
-    def ls(self, s3prefix, return_full_urls=False, require_s3_scheme=False, shallow=False, followlinks=False):
+    def ls(self, s3prefix, return_full_urls=False, require_s3_scheme=False, shallow=False, followlinks=False, list_versions=False):
         '''
         List files on AWS S3
         prefix is given as an S3 url: ``s3://bucket-name/path/to/dir``.
@@ -229,7 +229,13 @@ class S3Connection(object):
                 clean_paths = lambda x: "s3://" + k.netloc + path.sep + x.name
             else:
                 clean_paths = lambda x: path.sep + x.name
-            return itertools.imap(clean_paths, self._bucket(k.netloc).list(prefix=prefix, delimiter=delimiter))
+
+            if list_versions:
+                result_list_iterator = self._bucket(k.netloc).list_versions(prefix=prefix, delimiter=delimiter)
+            else:
+                result_list_iterator = self._bucket(k.netloc).list(prefix=prefix, delimiter=delimiter)
+
+            return itertools.imap(clean_paths, result_list_iterator)
         elif k.scheme == 'file':
             if require_s3_scheme:
                 raise InvalidSchemeException('URI should begin with s3://')

--- a/baiji/connection.py
+++ b/baiji/connection.py
@@ -495,7 +495,7 @@ class S3Connection(object):
         kwargs are passed directly on to s3.cp; see there for defaults.
         """
         self.cp(key_or_file_from, key_or_file_to, **kwargs)
-        self.rm(key_or_file_from, version_id=kwargs.get('version_id', None))
+        self.rm(key_or_file_from)
 
     def touch(self, key, encrypt=True):
         """

--- a/baiji/connection.py
+++ b/baiji/connection.py
@@ -66,7 +66,7 @@ class S3Connection(object):
 
         return bucket.lookup(key)
 
-    def cp(self, key_or_file_from, key_or_file_to, force=False, progress=False, policy=None, preserve_acl=False, encoding=None, encrypt=True, gzip=False, content_type=None, guess_content_type=False, metadata=None, skip=False, validate=True, max_size=None, version=None):
+    def cp(self, key_or_file_from, key_or_file_to, force=False, progress=False, policy=None, preserve_acl=False, encoding=None, encrypt=True, gzip=False, content_type=None, guess_content_type=False, metadata=None, skip=False, validate=True, max_size=None, version_id=None):
         """
         Copy file to or from AWS S3
 
@@ -95,7 +95,7 @@ class S3Connection(object):
         op.skip = skip
         op.validate = validate
         op.max_size = max_size
-        op.version = version
+        op.version_id = version_id
 
         if guess_content_type:
             op.guess_content_type()

--- a/baiji/copy.py
+++ b/baiji/copy.py
@@ -419,7 +419,17 @@ class S3CopyOperation(object):
         meta['Content-Encoding'] = key.content_encoding
         meta['Content-Type'] = key.content_type
         meta = dict(meta.items() + self.metadata.items())
-        self.dst.bucket.copy_key(self.dst.remote_path, self.src.bucket_name, src, preserve_acl=self.preserve_acl, metadata=meta, headers=headers, encrypt_key=self.encrypt)
+        self.dst.bucket.copy_key(
+            self.dst.remote_path,
+            self.src.bucket_name,
+            src,
+            preserve_acl=self.preserve_acl,
+            metadata=meta,
+            headers=headers,
+            encrypt_key=self.encrypt,
+            src_version_id=self.version_id
+        )
+
         if self.progress:
             print 'Copied %s to %s' % (self.src.uri, self.dst.uri)
 

--- a/baiji/exceptions.py
+++ b/baiji/exceptions.py
@@ -37,3 +37,6 @@ class S3Warning(RuntimeWarning):
 
 class EventualConsistencyWarning(S3Warning):
     pass
+
+class InvalidVersionID(S3Exception):
+    pass

--- a/baiji/package_version.py
+++ b/baiji/package_version.py
@@ -5,4 +5,4 @@
 #
 # See https://www.python.org/dev/peps/pep-0420/#namespace-packages-today
 
-__version__ = '2.6.1'
+__version__ = '2.7.0'

--- a/baiji/test_s3.py
+++ b/baiji/test_s3.py
@@ -400,14 +400,6 @@ class TestS3(TestAWSBase):
         s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL2', ''))
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL2', s3.path.basename(self.existing_remote_file))))
 
-    def test_s3_mv_versioned(self):
-        remote_versioned_file = self.existing_versioned_remote_file
-        version_id = s3.info(remote_versioned_file)['version_id']
-        s3.mv(remote_versioned_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version_id=version_id)
-
-        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL', 'TEST.foo')))
-        self.assertFalse(s3.exists(remote_versioned_file))
-
     def test_s3_rm(self):
         for path in [os.path.join(self.tmp_dir, 'foo'), self.remote_file("foo")]:
             s3.cp(self.local_file, path)

--- a/baiji/test_s3.py
+++ b/baiji/test_s3.py
@@ -176,6 +176,27 @@ class TestS3(TestAWSBase):
         s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL'))
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL', s3.path.basename(self.existing_remote_file))))
 
+    def test_s3_cp_download_versioned_success_with_valid_version_id(self):
+        version_id = s3.info(self.existing_remote_file)['version_id']
+        s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version=version_id)
+        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL', 'TEST.foo')))
+
+    def test_s3_cp_download_versioned_raise_key_not_found_with_unknown_version_id(self):
+
+        from baiji.exceptions import KeyNotFound
+        unknown_version_id = '5elgojhtA8BGJerqfbciN78eU74SJ9mX'
+        # test raise KeyNotFound with unknown versionId
+        with self.assertRaises(KeyNotFound):
+            s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version=unknown_version_id)
+
+    def test_s3_cp_download_versioned_raise_invalid_version_id_with_bad_version_id(self):
+        from baiji.exceptions import InvalidVersionID
+
+        invalid_version_id = '1111'
+        # test raise S3ResponseError with invalid versionId
+        with self.assertRaises(InvalidVersionID):
+            s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version=invalid_version_id)
+
     @mock.patch('baiji.copy.S3CopyOperation.ensure_integrity')
     def test_s3_cp_download_corrupted_recover_in_one_retry(self, ensure_integrity_mock):
         from baiji.exceptions import get_transient_error_class

--- a/baiji/test_s3.py
+++ b/baiji/test_s3.py
@@ -403,11 +403,12 @@ class TestS3(TestAWSBase):
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL2', s3.path.basename(self.existing_remote_file))))
 
     def test_s3_mv_versioned(self):
-        version_id = s3.info(self.existing_versioned_remote_file)['version_id']
-        s3.mv(self.existing_versioned_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version_id=version_id)
+        remote_versioned_file = self.existing_versioned_remote_file
+        version_id = s3.info(remote_versioned_file)['version_id']
+        s3.mv(remote_versioned_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version_id=version_id)
 
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL', 'TEST.foo')))
-        self.assertFalse(s3.exists(self.existing_versioned_remote_file))
+        self.assertFalse(s3.exists(remote_versioned_file))
 
     def test_s3_rm(self):
         for path in [os.path.join(self.tmp_dir, 'foo'), self.remote_file("foo")]:

--- a/baiji/test_s3.py
+++ b/baiji/test_s3.py
@@ -178,7 +178,7 @@ class TestS3(TestAWSBase):
 
     def test_s3_cp_download_versioned_success_with_valid_version_id(self):
         version_id = s3.info(self.existing_remote_file)['version_id']
-        s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version=version_id)
+        s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version_id=version_id)
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'DL', 'TEST.foo')))
 
     def test_s3_cp_download_versioned_raise_key_not_found_with_unknown_version_id(self):
@@ -187,7 +187,7 @@ class TestS3(TestAWSBase):
         unknown_version_id = '5elgojhtA8BGJerqfbciN78eU74SJ9mX'
         # test raise KeyNotFound with unknown versionId
         with self.assertRaises(KeyNotFound):
-            s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version=unknown_version_id)
+            s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version_id=unknown_version_id)
 
     def test_s3_cp_download_versioned_raise_invalid_version_id_with_bad_version_id(self):
         from baiji.exceptions import InvalidVersionID
@@ -195,7 +195,7 @@ class TestS3(TestAWSBase):
         invalid_version_id = '1111'
         # test raise S3ResponseError with invalid versionId
         with self.assertRaises(InvalidVersionID):
-            s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version=invalid_version_id)
+            s3.cp(self.existing_remote_file, os.path.join(self.tmp_dir, 'DL', 'TEST.foo'), version_id=invalid_version_id)
 
     @mock.patch('baiji.copy.S3CopyOperation.ensure_integrity')
     def test_s3_cp_download_corrupted_recover_in_one_retry(self, ensure_integrity_mock):

--- a/baiji/util/lookup.py
+++ b/baiji/util/lookup.py
@@ -7,7 +7,6 @@ def get_versioned_key_remote(bucket, key_name, version_id=None):
     from baiji.exceptions import InvalidVersionID
 
     key = None
-
     try:
         key = bucket.get_key(key_name, version_id=version_id)
     except S3ResponseError as e:
@@ -15,7 +14,4 @@ def get_versioned_key_remote(bucket, key_name, version_id=None):
             raise InvalidVersionID("Invalid versionID %s" % version_id)
         else:
             raise e
-
     return key
-
-

--- a/baiji/util/lookup.py
+++ b/baiji/util/lookup.py
@@ -1,4 +1,4 @@
-def get_versioned_key_remote(bucket, remote_path, version_id=None):
+def get_versioned_key_remote(bucket, key_name, version_id=None):
     '''
     Utility function to get versioned key from a bucket
 
@@ -9,7 +9,7 @@ def get_versioned_key_remote(bucket, remote_path, version_id=None):
     key = None
 
     try:
-        key = bucket.get_key(remote_path, version_id=version_id)
+        key = bucket.get_key(key_name, version_id=version_id)
     except S3ResponseError as e:
         if e.status == 400:
             raise InvalidVersionID("Invalid versionID %s" % version_id)

--- a/baiji/util/lookup.py
+++ b/baiji/util/lookup.py
@@ -1,0 +1,21 @@
+def get_versioned_key_remote(bucket, remote_path, version_id=None):
+    '''
+    Utility function to get versioned key from a bucket
+
+    '''
+    from boto.exception import S3ResponseError
+    from baiji.exceptions import InvalidVersionID
+
+    key = None
+
+    try:
+        key = bucket.get_key(remote_path, version_id=version_id)
+    except S3ResponseError as e:
+        if e.status == 400:
+            raise InvalidVersionID("Invalid versionID %s" % version_id)
+        else:
+            raise e
+
+    return key
+
+


### PR DESCRIPTION
The bodyfitter worker will be expected s3 urls with versionId metadata now.

The context is the effort to remove our original file upload->copy to storage process in the server code which adds complexity.