### PR TITLE
For loop over iterator

### DIFF
--- a/baiji/cli.py
+++ b/baiji/cli.py
@@ -34,7 +34,9 @@ class ListCommand(BaijiCommand):
                     enc = " enc" if info['encrypted'] else "    "
                     print "%s\t%s%s\t%s\t%s" % (sizeof_format_human_readable(info['size']), info['last_modified'], enc, key.encode('utf-8'), info['version_id'])
             else:
-                print u"\n".join(keys).encode('utf-8')
+                # print u"\n".join(keys).encode('utf-8')
+                for key in keys:
+                    print key
         except s3.InvalidSchemeException as e:
             print e
             return 1


### PR DESCRIPTION
This change allows for piping the output of the ls request without having to wait for the entire list to populate first.
E.g.:

```
    $ s3 ls s3://bucket/ | while read file; do s3 etag --fix $file ; done
```